### PR TITLE
Add cluster-federation CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ use this to inject your quay account name.
 #### Install federation using OLM
 
 Run the `scripts/install-using-catalog-source.sh` script to install federation
-into the `federation-test` namespace using OLM. This script also takes your
-quay.io account name as an argument:
+into the `federation-test` namespace using OLM. This script takes your quay
+account name as an argument, and optionally the type of deployment to subscribe
+to:
 
 ```
-$ scripts/install-using-catalog-source.sh pmorie
-catalogsource.operators.coreos.com/federation unchanged
-operatorgroup.operators.coreos.com/federation unchanged
-subscription.operators.coreos.com/federation unchanged
+$ scripts/install-using-catalog-source.sh pmorie <namespaced|cluster-scoped>
+catalogsource.operators.coreos.com/federation created
+operatorgroup.operators.coreos.com/namespaced-federation created
+subscription.operators.coreos.com/namespaced-federation-sub created
 ```
 
 This script:
@@ -91,3 +92,13 @@ This script:
 - Configures a `CatalogSource` for OLM that references the operator registry you built
 - Creates an `OperatorGroup` 
 - Creates a `Subscription` to the operator that drives OLM to install it in your namespace
+
+Note, if you run this script without an argument, you will get federation
+deployed in a namespaced scope. To deploy the cluster-scoped version, you should run:
+
+```
+$ ./scripts/install-using-catalog-source.sh pmorie cluster-scoped
+catalogsource.operators.coreos.com/federation created
+operatorgroup.operators.coreos.com/cluster-scoped-federation created
+subscription.operators.coreos.com/cluster-scoped-federation-sub created
+```

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-ClusterPropagatedVersion.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-ClusterPropagatedVersion.crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: clusterpropagatedversions.core.federation.k8s.io
+spec:
+  group: core.federation.k8s.io
+  names:
+    kind: ClusterPropagatedVersion
+    plural: clusterpropagatedversions
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            clusterVersions:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+            overridesVersion:
+              type: string
+            templateVersion:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-DNSEndpoint.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-DNSEndpoint.crd.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: dnsendpoints.multiclusterdns.federation.k8s.io
+spec:
+  group: multiclusterdns.federation.k8s.io
+  names:
+    kind: DNSEndpoint
+    plural: dnsendpoints
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            endpoints:
+              items:
+                properties:
+                  dnsName:
+                    type: string
+                  labels:
+                    type: object
+                  recordTTL:
+                    format: int64
+                    type: integer
+                  recordType:
+                    type: string
+                  targets:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-Domain.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-Domain.crd.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: domains.multiclusterdns.federation.k8s.io
+spec:
+  group: multiclusterdns.federation.k8s.io
+  names:
+    kind: Domain
+    plural: domains
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        domain:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        nameServer:
+          type: string
+      required:
+      - domain
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-FederatedCluster.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-FederatedCluster.crd.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: federatedclusters.core.federation.k8s.io
+spec:
+  group: core.federation.k8s.io
+  names:
+    kind: FederatedCluster
+    plural: federatedclusters
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterRef:
+              type: object
+            secretRef:
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            region:
+              type: string
+            zone:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-FederatedServiceStatus.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-FederatedServiceStatus.crd.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: federatedservicestatuses.core.federation.k8s.io
+spec:
+  group: core.federation.k8s.io
+  names:
+    kind: FederatedServiceStatus
+    plural: federatedservicestatuses
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        clusterStatus:
+          items:
+            properties:
+              clusterName:
+                type: string
+              status:
+                type: object
+            type: object
+          type: array
+        kind:
+          type: string
+        metadata:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-FederatedTypeConfig.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-FederatedTypeConfig.crd.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: federatedtypeconfigs.core.federation.k8s.io
+spec:
+  group: core.federation.k8s.io
+  names:
+    kind: FederatedTypeConfig
+    plural: federatedtypeconfigs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            comparisonField:
+              type: string
+            enableStatus:
+              type: boolean
+            namespaced:
+              type: boolean
+            override:
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                pluralName:
+                  type: string
+                version:
+                  type: string
+              required:
+              - kind
+              type: object
+            placement:
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                pluralName:
+                  type: string
+                version:
+                  type: string
+              required:
+              - kind
+              type: object
+            propagationEnabled:
+              type: boolean
+            status:
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                pluralName:
+                  type: string
+                version:
+                  type: string
+              required:
+              - kind
+              type: object
+            target:
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                pluralName:
+                  type: string
+                version:
+                  type: string
+              required:
+              - kind
+              type: object
+            template:
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                pluralName:
+                  type: string
+                version:
+                  type: string
+              required:
+              - kind
+              type: object
+          required:
+          - target
+          - namespaced
+          - comparisonField
+          - propagationEnabled
+          - template
+          - placement
+          - override
+          type: object
+        status:
+          properties:
+            observedGeneration:
+              format: int64
+              type: integer
+            propagationController:
+              type: string
+            statusController:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-IngressDNSRecord.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-IngressDNSRecord.crd.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: ingressdnsrecords.multiclusterdns.federation.k8s.io
+spec:
+  group: multiclusterdns.federation.k8s.io
+  names:
+    kind: IngressDNSRecord
+    plural: ingressdnsrecords
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            hosts:
+              items:
+                type: string
+              type: array
+            recordTTL:
+              format: int64
+              type: integer
+          type: object
+        status:
+          properties:
+            dns:
+              items:
+                properties:
+                  cluster:
+                    type: string
+                  loadBalancer:
+                    type: object
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-PropagatedVersion.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-PropagatedVersion.crd.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: propagatedversions.core.federation.k8s.io
+spec:
+  group: core.federation.k8s.io
+  names:
+    kind: PropagatedVersion
+    plural: propagatedversions
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            clusterVersions:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+            overridesVersion:
+              type: string
+            templateVersion:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-ReplicaSchedulingPreference.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-ReplicaSchedulingPreference.crd.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: replicaschedulingpreferences.scheduling.federation.k8s.io
+spec:
+  group: scheduling.federation.k8s.io
+  names:
+    kind: ReplicaSchedulingPreference
+    plural: replicaschedulingpreferences
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusters:
+              type: object
+            rebalance:
+              type: boolean
+            targetKind:
+              type: string
+            totalReplicas:
+              format: int32
+              type: integer
+          required:
+          - targetKind
+          - totalReplicas
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation-core-ServiceDNSRecord.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation-core-ServiceDNSRecord.crd.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  creationTimestamp: null
+  labels:
+    api: federation
+    kubebuilder.k8s.io: 1.0.4
+  name: servicednsrecords.multiclusterdns.federation.k8s.io
+spec:
+  group: multiclusterdns.federation.k8s.io
+  names:
+    kind: ServiceDNSRecord
+    plural: servicednsrecords
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            allowServiceWithoutEndpoints:
+              type: boolean
+            dnsPrefix:
+              type: string
+            domainRef:
+              type: string
+            externalName:
+              type: string
+            recordTTL:
+              format: int64
+              type: integer
+          required:
+          - domainRef
+          type: object
+        status:
+          properties:
+            dns:
+              items:
+                properties:
+                  cluster:
+                    type: string
+                  loadBalancer:
+                    type: object
+                  region:
+                    type: string
+                  zone:
+                    type: string
+                type: object
+              type: array
+            domain:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/0.0.5/cluster-federation.v0.0.5.clusterserviceversion.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-federation.v0.0.5.clusterserviceversion.yaml
@@ -3,17 +3,17 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: federation.v0.0.5
+  name: cluster-federation.v0.0.5
   namespace: placeholder
   annotations:
     capabilities: Basic Install
     categories: "OpenShift Optional, Integration & Delivery"
-    description: Gain Hybrid Cloud capabilities between your clusters with Kubernetes Federation.
+    description: Cluster-scoped Federation
     certified: "false"
     containerImage: "quay.io/openshift/origin-federation-controller:v4.0.0"
     createdAt: "2019-01-01T00:00:00Z"
 spec:
-  displayName: Federation
+  displayName: Cluster Federation
   description: |
     Kubernetes Federation is a tool to sync (aka "federate") a set of Kubernetes
     objects from a "source" into a set of other clusters. Common use-cases
@@ -23,10 +23,15 @@ spec:
     quickly get up and running with this powerful concept. Federation is a key
     part of any Hybrid Cloud capability.
 
-    This CSV deploys Federation scoped to the namespace it is deployed into.
-    Note that in this configuration, Federation cannot handle cluster-scoped
-    resources. Use this CSV if you want to add federation capability to a single
-    namespace.
+    This CSV deploys Federation scoped in a cluster-scoped configuration,
+    meaning that all namespaces in the cluster can be serviced by this version
+    of federation. Use this CSV if you want to add federation capability to all
+    namespaces in your cluster.
+    
+    In this configuration, Federation supports deploying cluster-scoped
+    resources. In this configuration, federation will watch
+    `FederatedTypeConfig` and `FederatedClusters` in the namespace it is
+    deployed into.
 
     ### Using Federation
     After configuring and starting your Federation instance, use the command
@@ -46,17 +51,18 @@ spec:
   provider:
     name: Red Hat
   labels:
-    alm-owner-federation: federation
-    alm-status-descriptors: federation.v0.0.5
+    alm-owner-federation: cluster-federation
+    alm-status-descriptors: cluster-federation.v0.0.5
   installModes:
   - type: OwnNamespace
     supported: true
   - type: SingleNamespace
+    # HACK: workaround for ALM-927
     supported: true
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
-    supported: false
+    supported: true
   install:
     strategy: deployment
     spec:
@@ -140,9 +146,8 @@ spec:
                     - /root/controller-manager
                   args:
                     - --federation-namespace=$(FEDERATION_NAMESPACE)
-                    - --install-crds=false
-                    - --limited-scope=true
                     - --registry-namespace=$(CLUSTER_REGISTRY_NAMESPACE)
+                    - --install-crds=false
                     - -v=5
                     - --logtostderr
                   imagePullPolicy: Always
@@ -161,23 +166,23 @@ spec:
               serviceAccount: federation-controller-manager
   customresourcedefinitions:
     owned:
-      - description: Represents endpoint information about a remote cluster
+      - description: Represents an instance of a Cluster Registry
         displayName: Cluster Registry Application
         kind: Cluster
         name: clusters.clusterregistry.k8s.io
         version: v1alpha1
-      - description: Represents a Domain name and nameserver for use with multicluster DNS
+      - description: Represents a Domain name and nameserver for use with multicluster DNS.
         displayName: Domain
         kind: Domain
         name: domains.multiclusterdns.federation.k8s.io
         version: v1alpha1
-      - description: Represents a Cluster that Federation can spread resources to
+      - description: Represents an instance of a FederatedCluster resource
         displayName: FederatedCluster Resource
         kind: FederatedCluster
         name: federatedclusters.core.federation.k8s.io
         version: v1alpha1
-      - description: Programs Federation to be aware of a new API type
-        displayName: Federation Type Configuration
+      - description: Represents an instance of a FederationV2 sync controller
+        displayName: FederationV2 Push Reconciler Application
         kind: FederatedTypeConfig
         name: federatedtypeconfigs.core.federation.k8s.io
         version: v1alpha1
@@ -186,7 +191,7 @@ spec:
         kind: FederatedServiceStatus
         name: federatedservicestatuses.core.federation.k8s.io
         version: v1alpha1        
-      - description: Represents information about the version of a federated resource
+      - description: Represents an instance of a PropagatedVersion resource
         displayName: PropagatedVersion Resource
         kind: PropagatedVersion
         name: propagatedversions.core.federation.k8s.io

--- a/manifests/cluster-federation/0.0.5/cluster-registry.crd.yaml
+++ b/manifests/cluster-federation/0.0.5/cluster-registry.crd.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    api: ""
+    kubebuilder.k8s.io: 0.1.10
+  name: clusters.clusterregistry.k8s.io
+spec:
+  group: clusterregistry.k8s.io
+  names:
+    kind: Cluster
+    plural: clusters
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authInfo:
+              properties:
+                controller:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                user:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+              type: object
+            kubernetesApiEndpoints:
+              properties:
+                caBundle:
+                  items:
+                    type: byte
+                  type: string
+                serverEndpoints:
+                  items:
+                    properties:
+                      clientCIDR:
+                        type: string
+                      serverAddress:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastHeartbeatTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/manifests/cluster-federation/cluster-federation.package.yaml
+++ b/manifests/cluster-federation/cluster-federation.package.yaml
@@ -1,0 +1,4 @@
+packageName: cluster-federation
+channels:
+- name: alpha
+  currentCSV: cluster-federation.v0.0.5

--- a/olm-testing/Dockerfile
+++ b/olm-testing/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine as munger
 ARG new_image_name
 COPY manifests manifests
 RUN sed "s,quay.io/openshift/origin-federation-controller,$new_image_name," -i manifests/federation/0.0.5/federation.v0.0.5.clusterserviceversion.yaml
+RUN sed "s,quay.io/openshift/origin-federation-controller,$new_image_name," -i manifests/cluster-federation/0.0.5/cluster-federation.v0.0.5.clusterserviceversion.yaml
 
 FROM quay.io/openshift/origin-operator-registry:latest
 

--- a/olm-testing/catalog-source.yaml
+++ b/olm-testing/catalog-source.yaml
@@ -8,4 +8,4 @@ spec:
   # Note, this image is not a real one. For development, use the
   # scripts/install-using-catalog-source.sh script to do a scripted installation
   # using images in an image registry you control.
-  image: quay.io/openshift/federation-operator-registry
+  image: quay.io/openshift/federation-operator-registry:v4.0.0

--- a/olm-testing/cluster-scoped-operator-group.yaml
+++ b/olm-testing/cluster-scoped-operator-group.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+ name: cluster-scoped-federation
+ namespace: federation-test

--- a/olm-testing/cluster-scoped-subscription.yaml
+++ b/olm-testing/cluster-scoped-subscription.yaml
@@ -1,11 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: federation
+  name: cluster-scoped-federation-sub
   namespace: federation-test
 spec:
   source: federation
   sourceNamespace: openshift-operator-lifecycle-manager
-  name: federation
-  startingCSV: federation.v0.0.5
+  name: cluster-federation
+  startingCSV: cluster-federation.v0.0.5
   channel: alpha

--- a/olm-testing/namespaced-operator-group.yaml
+++ b/olm-testing/namespaced-operator-group.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
- name: federation
+ name: namespaced-federation
  namespace: federation-test
 spec:
  targetNamespaces:

--- a/olm-testing/namespaced-subscription.yaml
+++ b/olm-testing/namespaced-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: namespaced-federation-sub
+  namespace: federation-test
+spec:
+  source: federation
+  sourceNamespace: openshift-operator-lifecycle-manager
+  name: federation
+  startingCSV: federation.v0.0.5
+  channel: alpha

--- a/scripts/install-using-catalog-source.sh
+++ b/scripts/install-using-catalog-source.sh
@@ -3,7 +3,15 @@
 # This script automates the work of installing federation using the
 # CatalogSource in the `olm-testing` directory.
 #
-# This script can be run from any directory.
+# This script can be run from any directory and takes two arguments:
+#
+# - The quay.io account name to use for the federation-operator-registry image
+# - The type of federation to subscribe to. There are two valid types:
+#
+# - namespaced
+# - cluster-scoped
+#
+# If the second argument is omitted, the default will be 'namespaced'.
 
 dir=$(realpath "$(dirname "${BASH_SOURCE}")/..")
 
@@ -13,6 +21,13 @@ if [[ -z "${registry}" ]]; then
   exit 1
 fi
 
+subscription_type=${2:-"namespaced"}
+declare -a subscription_types=("namespaced" "cluster-scoped")
+if ! [[ "${subscription_types[@]}" =~ (^|[[:space:]])"$subscription_type"($|[[:space:]]) ]] ; then
+  echo "${subscription_type} is an invalid type to subscribe to; use ${subscription_types[@]}"
+  exit 1
+fi
+
 sed -e "s,quay.io/openshift/federation-operator-registry,quay.io/$registry/federation-operator-registry," $dir/olm-testing/catalog-source.yaml | oc apply -f -
-oc apply -f $dir/olm-testing/operator-group.yaml
-oc apply -f $dir/olm-testing/subscription.yaml
+oc apply -f $dir/olm-testing/${subscription_type}-operator-group.yaml
+oc apply -f $dir/olm-testing/${subscription_type}-subscription.yaml

--- a/scripts/populate-community-operators.sh
+++ b/scripts/populate-community-operators.sh
@@ -11,11 +11,13 @@
 #   - src/github.com/openshift/federation-v2-operator
 #   - src/github.com/operator-framework/community-operators
 
+PACKAGE=${PACKAGE:-"federation"}
+
 dir=$(realpath "$(dirname "${BASH_SOURCE}")/..")
 community_operators_dir=$(realpath "${dir}/../../operator-framework/community-operators")
-target_dir="${community_operators_dir}/community-operators/federation"
+target_dir="${community_operators_dir}/community-operators/${PACKAGE}"
 rm -rf $target_dir
 mkdir -p $target_dir
 
-cp -r $dir/manifests/federation/0.0.5/* $target_dir
-cp $dir/manifests/federation/federation.package.yaml $target_dir
+cp -r $dir/manifests/${PACKAGE}/0.0.5/* $target_dir
+cp $dir/manifests/${PACKAGE}/${PACKAGE}.package.yaml $target_dir

--- a/scripts/populate-olm-crds.sh
+++ b/scripts/populate-olm-crds.sh
@@ -15,7 +15,7 @@
 
 FEDERATION_CHART_DIR=vendor/github.com/kubernetes-sigs/federation-v2/charts/federation-v2/
 PACKAGE=${PACKAGE:-"federation"}
-VERSION=${VERSION:-"0.0.4"}
+VERSION=${VERSION:-"0.0.5"}
 MANIFESTS_DIR=manifests/${PACKAGE}/${VERSION}
 
 echo "Populating OLM manifests for package ${PACKAGE} version ${VERSION}"

--- a/scripts/teardown-subscription.sh
+++ b/scripts/teardown-subscription.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+oc delete -n federation-test subscriptions --all
+oc delete -n federation-test installplans --all
+oc delete -n federation-test clusterserviceversions --all


### PR DESCRIPTION
Adds `cluster-federation` as a distinct CSV that supports a cluster-scoped deployment of federation in support of #29.

cc @csrwng 