### PR TITLE
Script cleanup + introduce makefile for ci

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,0 +1,26 @@
+# Makefile.ci holds make directives called by the CI jobs for this repo.
+
+populate-federation-gopath:
+	./scripts/populate-federation-gopath.sh
+
+.ONESHELL:
+unit: populate-federation-gopath
+	cd /go/src/github.com/kubernetes-sigs/federation-v2
+	go list ./pkg/... | grep -v v1alpha1 | xargs go test
+
+.ONESHELL:
+vet: populate-federation-gopath
+	cd /go/src/github.com/kubernetes-sigs/federation-v2
+	$(MAKE) vet
+
+.ONESHELL:
+managed-e2e: populate-federation-gopath
+	cd /go/src/github.com/kubernetes-sigs/federation-v2
+	./scripts/download-binaries.sh
+	TEST_ASSET_PATH="/go/src/github.com/kubernetes-sigs/federation-v2/bin" \
+	TEST_ASSET_ETCD="/go/src/github.com/kubernetes-sigs/federation-v2/bin/etcd" \
+	TEST_ASSET_KUBE_APISERVER="/go/src/github.com/kubernetes-sigs/federation-v2/bin/kube-apiserver" \
+	go test -v ./test/e2e -args -ginkgo.v -single-call-timeout=1m -ginkgo.trace -ginkgo.randomizeAllSpecs
+
+olm-e2e: populate-federation-gopath
+	echo "OK"

--- a/scripts/populate-federation-gopath.sh
+++ b/scripts/populate-federation-gopath.sh
@@ -1,8 +1,18 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+# This script populates the federation-v2 directory within a gopath directory
+# structure with the vendored federation-v2 source from this repo. It can be run
+# from any directory. The gopath directory structure is assumed to be rooted at
+# '/go' but can be overriden by setting the GOPATH_DIR environment variable.
+
+dir=$(realpath "$(dirname "${BASH_SOURCE}")/..")
+gopath_dir="${GOPATH_DIR:-"/go"}"
 
 federation_gp=github.com/kubernetes-sigs/federation-v2
-federation_src="/go/src/${federation_gp}"
-vendor_src="vendor/${federation_gp}"
+federation_src="${gopath_dir}/src/${federation_gp}"
+vendor_src="${dir}/vendor/${federation_gp}"
+
+echo "Populating federation-v2 gopath at ${federation_src}"
 mkdir -p $federation_src
 cp $vendor_src/Makefile $federation_src/Makefile
 cp -r $vendor_src/pkg $federation_src/pkg


### PR DESCRIPTION
...in order to facilitate CI calling only makefile targets instead of containing the actual commands run.