### PR TITLE
Fix typo in OLM link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ using [ci-operator](https://github.com/openshift/ci-operator) as part of the
 [OpenShift](https://openshift.com) build process.
 
 Federation v2 is deployed as an [operator](https://coreos.com/operators) using
-[OLM](https://github.com/operator-framework/operator-lifecycle-management).
+[OLM](https://github.com/operator-framework/operator-lifecycle-manager).
 
 ### Layout of this repository
 


### PR DESCRIPTION
s/management/manager

Signed-off-by: Jamo Luhrsen <jluhrsen@redhat.com>