### PR TITLE
Updated instructions for getting kubefed2 from GH releases

### DIFF
--- a/manifests/federation/0.0.7/federation.v0.0.7.clusterserviceversion.yaml
+++ b/manifests/federation/0.0.7/federation.v0.0.7.clusterserviceversion.yaml
@@ -58,11 +58,9 @@ spec:
     ### Get the kubefed2 CLI tool
 
     Before you use federation, you should ensure that you're using the binary
-    for this version. You can get it by copying it from the image.
+    for this version. You can get it from the releases on GitHub.
 
-        docker run --name=hyperfed --entrypoint=/bin/sh quay.io/openshift/origin-federation-controller:v4.0.0 sleep 50000
-        docker cp hyperfed:/root/hyperfed hyperfed
-        ln -s hyperfed kubefed2
+        curl -Ls https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.7/kubefed2.tar.gz | tar xz
 
     ### Joining Clusters
 

--- a/upstream-manifests/federation/0.0.7/federation.v0.0.7.clusterserviceversion.yaml
+++ b/upstream-manifests/federation/0.0.7/federation.v0.0.7.clusterserviceversion.yaml
@@ -58,11 +58,9 @@ spec:
     ### Get the kubefed2 CLI tool
 
     Before you use federation, you should ensure that you're using the binary
-    for this version. You can get it by copying it from the image.
+    for this version. You can get it from the releases on GitHub.
 
-        docker run --name=hyperfed --entrypoint=/bin/sh quay.io/kubernetes-multicluster/federation-v2:v0.0.7 sleep 50000
-        docker cp hyperfed:/root/hyperfed hyperfed
-        ln -s hyperfed kubefed2
+        curl -Ls https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.7/kubefed2.tar.gz | tar xz
 
     ### Joining Clusters
 


### PR DESCRIPTION
Getting the kubefed2 binary from the GitHub's releases rather than from a Docker container running locally.

This way users don't need to run a container locally to get the kubefed2 binary.